### PR TITLE
Add SPI Methods trait and vtable

### DIFF
--- a/rust/kernel/spi.rs
+++ b/rust/kernel/spi.rs
@@ -168,33 +168,6 @@ unsafe impl Sync for DriverRegistration {}
 // SAFETY: All functions work from any thread.
 unsafe impl Send for DriverRegistration {}
 
-#[macro_export]
-macro_rules! spi_method {
-    (fn $method_name:ident (mut $device_name:ident : SpiDevice) -> Result $block:block) => {
-        unsafe extern "C" fn $method_name(dev: *mut kernel::bindings::spi_device) -> kernel::c_types::c_int {
-            use kernel::spi::SpiDevice;
-
-            fn inner(mut $device_name: SpiDevice) -> Result $block
-
-            // SAFETY: The dev pointer is provided by the kernel and is sure to be valid
-            match inner(unsafe { SpiDevice::from_ptr(spi_dev) }) {
-                Ok(_) => 0,
-                Err(e) => e.to_kernel_errno(),
-            }
-        }
-    };
-    (fn $method_name:ident (mut $device_name:ident : SpiDevice) $block:block) => {
-        unsafe extern "C" fn $method_name(dev: *mut kernel::bindings::spi_device) {
-            use kernel::spi::SpiDevice;
-
-            fn inner(mut $device_name: SpiDevice) $block
-
-            // SAFETY: The dev pointer is provided by the kernel and is sure to be valid
-            inner(unsafe { SpiDevice::from_ptr(spi_dev) })
-        }
-    };
-}
-
 pub struct Spi;
 
 impl Spi {


### PR DESCRIPTION
This will need a few refactorings, but I'd like to get the first basic implementation reviewed. This is super similar to what's being done in `FileOperations` and would probably deserve some code factoring (for example, a general macro to declare "vtables" and their usage in a generic trait.

I also wonder if this part
```rust
         match T::TO_USE.probe {
            false => spi_driver.probe = None,
            true => spi_driver.probe = Some(DriverRegistration::probe_wrapper::<T>),
        }
        match T::TO_USE.remove {
            false => spi_driver.remove = None,
            true => spi_driver.remove = Some(DriverRegistration::remove_wrapper::<T>),
        }
        match T::TO_USE.shutdown {
            false => spi_driver.shutdown = None,
            true => spi_driver.shutdown = Some(DriverRegistration::shutdown_wrapper::<T>),
        }
```
would benefit from some sort of macro or private function? Since it's very repetitive code, we could do something like
```rust
fn get_wrapper<F>(usage: bool, fn: F) -> Option<F> {
    match usage {
        false => None,
        true => Some(F),
    }
}
```

Please let me know what you guys think :)