### PR TITLE
Add SPI documentation

### DIFF
--- a/rust/kernel/spi.rs
+++ b/rust/kernel/spi.rs
@@ -1,5 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0
 
+//! This module provides safer and higher level abstraction over the kernel's SPI types
+//! and functions.
+//!
+//! C header: [`include/linux/spi/spi.h`](../../../../include/linux/spi/spi.h)
+
 use crate::bindings;
 use crate::c_types;
 use crate::error::{Error, Result};
@@ -7,19 +12,33 @@ use crate::str::CStr;
 use alloc::boxed::Box;
 use core::pin::Pin;
 
+/// Wrapper struct around the kernel's `spi_device`
 #[derive(Clone, Copy)]
 pub struct SpiDevice(*mut bindings::spi_device);
 
 impl SpiDevice {
+    /// Create an SpiDevice from a mutable spi_device raw pointer. This function is unsafe
+    /// as the pointer might be invalid.
+    ///
+    /// # Safety
+    ///
+    /// The pointer must be valid. This can be achieved by calling `to_ptr` on a previously
+    /// constructed, safe SpiDevice instance, or by making sure that the pointer points
+    /// to valid memory.
+    /// You probably do not want to use this abstraction directly. It is mainly used
+    /// by this abstraction to wrap valid pointers given by the Kernel to the different
+    /// spi methods: probe, remove and shutdown
     pub unsafe fn from_ptr(dev: *mut bindings::spi_device) -> Self {
         SpiDevice(dev)
     }
 
+    /// Access the raw pointer from an SpiDevice instance
     pub fn to_ptr(&mut self) -> *mut bindings::spi_device {
         self.0
     }
 }
 
+/// Registration of an SPI driver
 pub struct DriverRegistration {
     this_module: &'static crate::ThisModule,
     registered: bool,
@@ -27,33 +46,48 @@ pub struct DriverRegistration {
     spi_driver: bindings::spi_driver,
 }
 
+/// Represents which methods of the SPI driver shall be implemented
 pub struct ToUse {
+    /// The `probe` field of `spi_driver`
     pub probe: bool,
+
+    /// The `remove` field of `spi_driver`
     pub remove: bool,
+
+    /// The `shutdown` field of `spi_driver`
     pub shutdown: bool,
 }
 
+/// Default table to use for SPI methods. All fields are set to false, meaning that the
+/// kernel's default implementations will be used.
 pub const USE_NONE: ToUse = ToUse {
     probe: false,
     remove: false,
     shutdown: false,
 };
 
+/// Corresponds to the kernel's spi_driver's methods. Implement this trait on a type to
+/// express the need of a custom probe, remove or shutdown function for your SPI driver.
+/// Use the [`declare_spi_methods`] macro to declare which methods you wish to use.
 pub trait SpiMethods {
+    /// The methods to define. Use [`declare_spi_methods`] to declare them
     const TO_USE: ToUse;
 
+    /// Corresponds to the kernel's spi_driver's probe method field
     fn probe(mut _spi_dev: SpiDevice) -> Result {
         Ok(())
     }
 
+    /// Corresponds to the kernel's spi_driver's remove method field
     fn remove(mut _spi_dev: SpiDevice) -> Result {
         Ok(())
     }
 
+    /// Corresponds to the kernel's spi_driver's shutdown method field
     fn shutdown(mut _spi_dev: SpiDevice) {}
 }
 
-/// Populate the TO_USE field in the `SpiMethods` implementer
+/// Populate the TO_USE field in the [`SpiMethods`] implementer
 ///
 /// ```rust
 /// impl SpiMethods for MySpiMethods {
@@ -101,7 +135,15 @@ impl DriverRegistration {
         }
     }
 
-    // FIXME: Add documentation
+    /// Create a new `DriverRegistration` and register it. This is equivalent to creating
+    /// a static `spi_driver` and then calling `spi_driver_register` on it in C.
+    ///
+    /// ```
+    /// // The function returns a result, which you need to handle. Use the `?` operator
+    /// // to propagate it
+    /// let spi_driver =
+    ///     spi::DriverRegistration::new_pinned::<MySpiMethods>(&THIS_MODULE, cstr!("my_driver_name"))?;
+    /// ```
     pub fn new_pinned<T: SpiMethods>(
         this_module: &'static crate::ThisModule,
         name: &'static CStr,
@@ -138,8 +180,9 @@ impl DriverRegistration {
         T::shutdown(SpiDevice::from_ptr(spi_dev))
     }
 
-    // FIXME: Add documentation
-    pub fn register<T: SpiMethods>(self: Pin<&mut Self>) -> Result {
+    /// Register a [`DriverRegistration`]. This is equivalent to calling `spi_driver_register`
+    /// on your `spi_driver` in C, without creating it first.
+    fn register<T: SpiMethods>(self: Pin<&mut Self>) -> Result {
         let this = unsafe { self.get_unchecked_mut() };
         if this.registered {
             return Err(Error::EINVAL);
@@ -174,8 +217,6 @@ impl Drop for DriverRegistration {
     }
 }
 
-// FIXME: Fix SAFETY documentation
-
 // SAFETY: The only method is `register()`, which requires a (pinned) mutable `Registration`, so it
 // is safe to pass `&Registration` to multiple threads because it offers no interior mutability.
 unsafe impl Sync for DriverRegistration {}
@@ -183,9 +224,19 @@ unsafe impl Sync for DriverRegistration {}
 // SAFETY: All functions work from any thread.
 unsafe impl Send for DriverRegistration {}
 
+/// High level abstraction over the kernel's spi functions such as `spi_write_then_read`.
 pub struct Spi;
 
 impl Spi {
+    /// Corresponds to the kernel's `spi_write_then_read`
+    ///
+    /// ```
+    /// let to_write = "rust-for-linux".as_bytes();
+    /// let mut to_receive = [0u8; 10]; // let's receive 10 bytes back
+    ///
+    /// // `spi_device` was previously provided by the kernel in that case
+    /// let transfer_result = Spi::write_then_read(spi_device, &to_write, &mut to_receive);
+    /// ```
     pub fn write_then_read(dev: &mut SpiDevice, tx_buf: &[u8], rx_buf: &mut [u8]) -> Result {
         let res = unsafe {
             bindings::spi_write_then_read(
@@ -203,10 +254,25 @@ impl Spi {
         }
     }
 
+    /// Corresponds to the kernel's `spi_write`
+    ///
+    /// ```
+    /// let to_write = "rust-for-linux".as_bytes();
+    ///
+    /// // `spi_device` was previously provided by the kernel in that case
+    /// let write_result = Spi::write(spi_device, &to_write);
+    /// ```
     pub fn write(dev: &mut SpiDevice, tx_buf: &[u8]) -> Result {
         Spi::write_then_read(dev, tx_buf, &mut [0u8; 0])
     }
 
+    /// Corresponds to the kernel's `spi_read`
+    ///
+    /// ```
+    /// let mut to_receive = [0u8; 10]; // let's receive 10 bytes
+    ///
+    /// // `spi_device` was previously provided by the kernel in that case
+    /// let transfer_result = Spi::read(spi_device, &mut to_receive);
     pub fn read(dev: &mut SpiDevice, rx_buf: &mut [u8]) -> Result {
         Spi::write_then_read(dev, &[0u8; 0], rx_buf)
     }


### PR DESCRIPTION
Add missing documentation on Rust structures and functions.
We can now generate documentation without errors. To see the rendered doc:

```sh
> make rustdoc # You need to pass LLVM=1 etc... as usual
> # Open rust/doc/kernel/spi/index.html in a browser
> firefox-nightly rust/doc/kernel/spi/index.html
```